### PR TITLE
parsers: don't attempt to access the `.path` attribute of `FileField` objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
 
 setup(
     name = "django-wapiti",
-    version = "1.0.0",
+    version = "1.0.1",
     packages = find_packages(),
     description = description,
     author = "Ecometrica",


### PR DESCRIPTION
Depending on the storage, a `FileField` object may or may not have an
absolute path. For example, it may not exist for remote network
storage. It is thus incorrect to attempt to access it in general.
Thus, we only pass the object instead. The called file handler may
still decide to do something with the `FileField`.

For backwards compatibility, we must check if we've been passed a file
handler that expects the path and the name being passed in separate
arguments. If so, we pass them in, regardless of the problem that this
incurs.
