### PR TITLE
use isodate instead of strftime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,11 @@ v1.0.2
 * Previous version forgot to handle the case of no file handler being
   supplied. This release fixes that.
 
+v1.0.3
+~~~~~~
+
+* Allow serialising pre-1900 dates.
+
 .. _Ecometrica: http://ecometrica.com
 .. _JSON: http://json.org
 

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setup(
         "Framework :: Django",
         ],
     long_description = long_description,
+    test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
 
 setup(
     name = "django-wapiti",
-    version = "1.0.2",
+    version = "1.0.3",
     packages = find_packages(),
     description = description,
     author = "Ecometrica",

--- a/tests
+++ b/tests
@@ -1,0 +1,1 @@
+wapiti/tests

--- a/wapiti/__init__.py
+++ b/wapiti/__init__.py
@@ -4,5 +4,5 @@
 
 #_register_models()
 
-VERSION = '1.0.1'
+VERSION = '1.0.3'
 

--- a/wapiti/parsers.py
+++ b/wapiti/parsers.py
@@ -227,7 +227,7 @@ class Encoder(object):
             for k, v in value.iteritems():
                 value[k] = self.convert(v, depth)
         elif isinstance(value, dt.date):
-            value = value.strftime(DATE_FORMAT)
+            value = value.isoformat()
         elif isinstance(value, Decimal):
             value = float(value)
         elif isinstance(value, FieldFile):

--- a/wapiti/tests/test_parsers.py
+++ b/wapiti/tests/test_parsers.py
@@ -2,7 +2,10 @@
 # Distributed under the BSD license. See LICENSE for details.
 import unittest
 
+from datetime import date
+
 from wapiti.parsers import Decoder, Encoder
+
 
 class TestJSONDecode(unittest.TestCase):
 
@@ -15,12 +18,17 @@ class TestJSONDecode(unittest.TestCase):
 
     def test_list(self):
         self.assertEqual(self.decoder.decode('["FOO"]'), ["FOO"])
-        
+
     def test_dict(self):
         self.assertEqual(self.decoder.decode('{"FOO":"BAR"}'), {"FOO": "BAR"})
 
     def test_nested(self):
         self.assertEqual(self.decoder.decode('{"FOO":["BAR"]}'), {"FOO": ["BAR"]})
+
+    def test_date(self):
+        self.assertEqual(self.decoder.decode('1945-09-02'), date(1945, 9, 2))
+        self.assertEqual(self.decoder.decode('1820-09-16'), date(1820, 9, 16))
+
 
 class TestJSONEncode(unittest.TestCase):
 
@@ -31,14 +39,17 @@ class TestJSONEncode(unittest.TestCase):
         self.assertEqual(self.encoder.encode("FOO"), '"FOO"')
 
     def test_list(self):
-        self.assertEqual(self.encoder.encode(["FOO",]), '["FOO"]')
-        
+        self.assertEqual(self.encoder.encode(["FOO"]), '["FOO"]')
+
     def test_dict(self):
         self.assertEqual(self.encoder.encode({"FOO": "BAR"}), '{"FOO": "BAR"}')
 
     def test_nested(self):
-        self.assertEqual(self.encoder.encode({"FOO":["BAR"]}), '{"FOO": ["BAR"]}')
+        self.assertEqual(self.encoder.encode({"FOO": ["BAR"]}), '{"FOO": ["BAR"]}')
+
+    def test_date(self):
+        self.assertEqual(self.encoder.encode(date(1945, 8, 2)), '"1945-08-02"')
+        self.assertEqual(self.encoder.encode(date(1820, 9, 16)), '"1820-09-16"')
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Our DATE_FORMAT is always ISO anyway, and we have this Python bug in Python 2:

http://bugs.python.org/issue1777412

So this is a simple workaround dates before 1900.
